### PR TITLE
msm8226-common: Add FM_RX and FM_RX_A2DP to attached input device list

### DIFF
--- a/configs/audio_policy.conf
+++ b/configs/audio_policy.conf
@@ -5,7 +5,7 @@
 global_configuration {
   attached_output_devices AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_SPEAKER
   default_output_device AUDIO_DEVICE_OUT_SPEAKER
-  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_REMOTE_SUBMIX
+  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_REMOTE_SUBMIX|AUDIO_DEVICE_IN_FM_RX|AUDIO_DEVICE_IN_FM_RX_A2DP
 }
 
 # audio hardware module section: contains descriptors for all audio hw modules present on the


### PR DESCRIPTION
- FM_RX and FM_RX_A2DP are not physically connected/disconnected
from a device runtime.
- Hence if a device supports these devices, add them to
attached input device list.

Change-Id: I6d8d0a15ecba1cd382fc0957ea75bc6b4d2d6572